### PR TITLE
[video_player]:视频缓存key的优化

### DIFF
--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -494,7 +494,9 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   }
   [KTVHTTPCache encodeSetURLConverter:^NSURL *(NSURL *URL) {
     NSLog(@"URL Filter reviced URL : %@", URL);
-    return URL;
+
+    NSString *newPath = [NSString stringWithFormat:@"%@://%@\%@", URL.scheme, URL.host, URL.path];
+    return [NSURL URLWithString:newPath];
   }];
   [KTVHTTPCache downloadSetUnacceptableContentTypeDisposer:^BOOL(NSURL *URL, NSString *contentType) {
     NSLog(@"Unsupport Content-Type Filter reviced URL : %@, %@", URL, contentType);


### PR DESCRIPTION
1.自定义关联播放地址，去掉播放地址中的查询参数关联播放地址
