### PR TITLE
[video_player]:修复 iOS Restyle video 对比视频时两个视频一致问题。

### DIFF
--- a/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
+++ b/packages/video_player/video_player/ios/Classes/FLTVideoPlayerPlugin.m
@@ -497,7 +497,10 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
   }
   [KTVHTTPCache encodeSetURLConverter:^NSURL *(NSURL *URL) {
     NSLog(@"URL Filter reviced URL : %@", URL);
-    return URL;
+    // 视频链接带有时效参数，但视频文件是同一个，此处缓存时使用去除参数的链接作为 key。
+    // flutter 侧传入 useCache 和 cacheKey 参数，其中 cacheKey 是由视频链接去除参数后 MD5 生成。此处规则保持一致。
+    // 如需修改此处规则，注意与 flutter 侧保持一致。
+    return [NSURL URLWithString:[NSString stringWithFormat:@"%@://%@%@", [URL scheme], [URL host], [URL path]]];
   }];
   [KTVHTTPCache downloadSetUnacceptableContentTypeDisposer:^BOOL(NSURL *URL, NSString *contentType) {
     NSLog(@"Unsupport Content-Type Filter reviced URL : %@, %@", URL, contentType);
@@ -571,15 +574,6 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
     player = [[FLTVideoPlayer alloc] initWithAsset:assetPath frameUpdater:frameUpdater];
     return [self onPlayerSetup:player frameUpdater:frameUpdater];
   } else if (input.uri) {
-    if(input.cacheKey != nil && (NSNull *)input.cacheKey != [NSNull null]) {
-      [KTVHTTPCache encodeSetURLConverter:^NSURL *(NSURL *URL) {
-        return [NSURL URLWithString:input.cacheKey];
-      }];
-    } else {
-        [KTVHTTPCache encodeSetURLConverter:^NSURL *(NSURL *URL) {
-          return URL;
-        }];
-    }
     player = [[FLTVideoPlayer alloc] initWithURL:[NSURL URLWithString:input.uri]
                                     frameUpdater:frameUpdater
                                      httpHeaders:input.httpHeaders


### PR DESCRIPTION
缓存组件 KTVHTTPCache 提供接口 encodeSetURLConverter，允许用户传入 block 处理 url 再进行内部映射缓存。
原先实现是在需要播放视频时，block 内返回 flutter 侧生成的 cacheKey。在单视频播放场景没有问题。
但多视频播放场景，如任务详情页对比视频，会先后更新 block。但在组件内部下载缓存视频文件时，会多次调用 block，可能导致一个视频缓存中途因 block 被更新，导致缓存文件出错。

解决方法：encodeSetURLConverter 传入的 block 改为返回去除参数的视频链接，该规则与 flutter 侧生成 cacheKey 保持一致。在多视频场景，每次调用 block 会根据视频 url 不同获取不同缓存文件。